### PR TITLE
Add Horizontal Rule

### DIFF
--- a/src/Nodes/HorizontalRule.php
+++ b/src/Nodes/HorizontalRule.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ProseMirrorToHtml\Nodes;
+
+class HorizontalRule extends Node
+{
+    protected $nodeType = 'horizontal_rule';
+    protected $tagName = 'hr';
+
+    public function selfClosing()
+    {
+        return true;
+    }
+}

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -12,6 +12,7 @@ class Renderer
         Nodes\CodeBlock::class,
         Nodes\HardBreak::class,
         Nodes\Heading::class,
+        Nodes\HorizontalRule::class,
         Nodes\Image::class,
         Nodes\ListItem::class,
         Nodes\OrderedList::class,

--- a/tests/Nodes/HorizontalRuleNodeTest.php
+++ b/tests/Nodes/HorizontalRuleNodeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ProseMirrorToHtml\Test\Nodes;
+
+use ProseMirrorToHtml\Renderer;
+use ProseMirrorToHtml\Test\TestCase;
+
+class HorizontalRuleNodeTest extends TestCase
+{
+    /** @test */
+    public function self_closing_node_gets_rendered_correctly()
+    {
+        $json = [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'type' => 'text',
+                            'text' => 'some text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'horizontal_rule',
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'type' => 'text',
+                            'text' => 'some more text',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $html = '<p>some text</p><hr><p>some more text</p>';
+
+        $this->assertEquals($html, (new Renderer)->render($json));
+    }
+}


### PR DESCRIPTION
This adds support for `hr` tags.

Tiptap can add them, but this package can't render them.